### PR TITLE
Fix multiple tsan reported issues. (#1487)

### DIFF
--- a/src/mcts/params.cc
+++ b/src/mcts/params.cc
@@ -370,6 +370,7 @@ SearchParams::SearchParams(const OptionsDict& options)
       kCpuctFactorAtRoot(options.Get<float>(
           options.Get<bool>(kRootHasOwnCpuctParamsId) ? kCpuctFactorAtRootId
                                                       : kCpuctFactorId)),
+      kTwoFoldDraws(options.Get<bool>(kTwoFoldDrawsId)),
       kNoiseEpsilon(options.Get<float>(kNoiseEpsilonId)),
       kNoiseAlpha(options.Get<float>(kNoiseAlphaId)),
       kFpuAbsolute(options.Get<std::string>(kFpuStrategyId) == "absolute"),

--- a/src/mcts/params.h
+++ b/src/mcts/params.h
@@ -53,7 +53,7 @@ class SearchParams {
   float GetCpuctFactor(bool at_root) const {
     return at_root ? kCpuctFactorAtRoot : kCpuctFactor;
   }
-  bool GetTwoFoldDraws() const { return options_.Get<bool>(kTwoFoldDrawsId); }
+  bool GetTwoFoldDraws() const { return kTwoFoldDraws; }
   float GetTemperature() const { return options_.Get<float>(kTemperatureId); }
   float GetTemperatureVisitOffset() const {
     return options_.Get<float>(kTemperatureVisitOffsetId);
@@ -179,6 +179,7 @@ class SearchParams {
   const float kCpuctBaseAtRoot;
   const float kCpuctFactor;
   const float kCpuctFactorAtRoot;
+  const bool kTwoFoldDraws;
   const float kNoiseEpsilon;
   const float kNoiseAlpha;
   const bool kFpuAbsolute;

--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -186,7 +186,7 @@ void ApplyDirichletNoise(Node* node, float eps, double alpha) {
 }
 }  // namespace
 
-void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
+void Search::SendUciInfo() REQUIRES(nodes_mutex_) REQUIRES(counters_mutex_) {
   const auto max_pv = params_.GetMultiPv();
   const auto edges = GetBestChildrenNoTemperature(root_node_, max_pv, 0);
   const auto score_type = params_.GetScoreType();
@@ -310,7 +310,7 @@ int64_t Search::GetTimeSinceStart() const {
       .count();
 }
 
-int64_t Search::GetTimeSinceFirstBatch() const {
+int64_t Search::GetTimeSinceFirstBatch() const REQUIRES(counters_mutex_) {
   if (!nps_start_time_) return 0;
   return std::chrono::duration_cast<std::chrono::milliseconds>(
              std::chrono::steady_clock::now() - *nps_start_time_)
@@ -571,6 +571,7 @@ void Search::ResetBestMove() {
 void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
     REQUIRES(counters_mutex_) {
   if (bestmove_is_sent_) return;
+  if (root_node_->GetN() == 0) return;
   if (!root_node_->HasChildren()) return;
 
   float temperature = params_.GetTemperature();
@@ -600,7 +601,7 @@ void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
                            : GetBestChildNoTemperature(root_node_, 0);
   final_bestmove_ = bestmove_edge.GetMove(played_history_.IsBlackToMove());
 
-  if (bestmove_edge.HasNode() && bestmove_edge.node()->HasChildren()) {
+  if (bestmove_edge.GetN() > 0 && bestmove_edge.node()->HasChildren()) {
     final_pondermove_ = GetBestChildNoTemperature(bestmove_edge.node(), 1)
                             .GetMove(!played_history_.IsBlackToMove());
   }
@@ -610,6 +611,9 @@ void Search::EnsureBestMoveKnown() REQUIRES(nodes_mutex_)
 std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
                                                               int count,
                                                               int depth) const {
+  // Even if Edges is populated at this point, its a race condition to access
+  // the node, so exit quickly.
+  if (parent->GetN() == 0) return {};
   const bool is_odd_depth = (depth % 2) == 1;
   const float draw_score = GetDrawScore(is_odd_depth);
   // Best child is selected using the following criteria:
@@ -648,7 +652,10 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
           // This default isn't used as wl only checked for case edge is
           // terminal.
           const auto wl = edge.GetWL(0.0f);
-          if (!edge.IsTerminal() || !wl) return kNonTerminal;
+          // Not safe to access IsTerminal if GetN is 0.
+          if (edge.GetN() == 0 || !edge.IsTerminal() || !wl) {
+            return kNonTerminal;
+          }
           if (edge.IsTbTerminal()) {
             return wl < 0.0 ? kTablebaseLoss : kTablebaseWin;
           }
@@ -661,7 +668,9 @@ std::vector<EdgeAndNode> Search::GetBestChildrenNoTemperature(Node* parent,
         if (a_rank != b_rank) return a_rank > b_rank;
 
         // If both are terminal draws, try to make it shorter.
-        if (a_rank == kNonTerminal && a.IsTerminal() && b.IsTerminal()) {
+        // Not safe to access IsTerminal if GetN is 0.
+        if (a_rank == kNonTerminal && a.GetN() != 0 && b.GetN() != 0 &&
+            a.IsTerminal() && b.IsTerminal()) {
           if (a.IsTbTerminal() != b.IsTbTerminal()) {
             // Prefer non-tablebase draws.
             return a.IsTbTerminal() < b.IsTbTerminal();
@@ -801,9 +810,12 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
   stats->time_since_movestart = GetTimeSinceStart();
 
   SharedMutex::SharedLock nodes_lock(nodes_mutex_);
-  stats->time_since_first_batch = GetTimeSinceFirstBatch();
-  if (!nps_start_time_ && total_playouts_ > 0) {
-    nps_start_time_ = std::chrono::steady_clock::now();
+  {
+    Mutex::Lock counters_lock(counters_mutex_);
+    stats->time_since_first_batch = GetTimeSinceFirstBatch();
+    if (!nps_start_time_ && total_playouts_ > 0) {
+      nps_start_time_ = std::chrono::steady_clock::now();
+    }
   }
   stats->total_nodes = total_playouts_ + initial_visits_;
   stats->nodes_since_movestart = total_playouts_;
@@ -813,33 +825,38 @@ void Search::PopulateCommonIterationStats(IterationStats* stats) {
   stats->win_found = false;
   stats->time_usage_hint_ = IterationStats::TimeUsageHint::kNormal;
 
-  const auto draw_score = GetDrawScore(true);
-  const float fpu =
-      GetFpu(params_, root_node_, /* is_root_node */ true, draw_score);
-  float max_q_plus_m = -1000;
-  uint64_t max_n = 0;
-  bool max_n_has_max_q_plus_m = true;
-  const auto m_evaluator = network_->GetCapabilities().has_mlh()
-                               ? MEvaluator(params_, root_node_)
-                               : MEvaluator();
-  for (const auto& edge : root_node_->Edges()) {
-    const auto n = edge.GetN();
-    const auto q = edge.GetQ(fpu, draw_score);
-    const auto m = m_evaluator.GetM(edge, q);
-    const auto q_plus_m = q + m;
-    stats->edge_n.push_back(n);
-    if (edge.IsTerminal() && edge.GetWL(0.0f) > 0.0f) stats->win_found = true;
-    if (max_n < n) {
-      max_n = n;
-      max_n_has_max_q_plus_m = false;
+  // If root node hasn't finished first visit, none of this code is safe.
+  if (root_node_->GetN() > 0) {
+    const auto draw_score = GetDrawScore(true);
+    const float fpu =
+        GetFpu(params_, root_node_, /* is_root_node */ true, draw_score);
+    float max_q_plus_m = -1000;
+    uint64_t max_n = 0;
+    bool max_n_has_max_q_plus_m = true;
+    const auto m_evaluator = network_->GetCapabilities().has_mlh()
+                                 ? MEvaluator(params_, root_node_)
+                                 : MEvaluator();
+    for (const auto& edge : root_node_->Edges()) {
+      const auto n = edge.GetN();
+      const auto q = edge.GetQ(fpu, draw_score);
+      const auto m = m_evaluator.GetM(edge, q);
+      const auto q_plus_m = q + m;
+      stats->edge_n.push_back(n);
+      if (n > 0 && edge.IsTerminal() && edge.GetWL(0.0f) > 0.0f) {
+        stats->win_found = true;
+      }
+      if (max_n < n) {
+        max_n = n;
+        max_n_has_max_q_plus_m = false;
+      }
+      if (max_q_plus_m <= q_plus_m) {
+        max_n_has_max_q_plus_m = (max_n == n);
+        max_q_plus_m = q_plus_m;
+      }
     }
-    if (max_q_plus_m <= q_plus_m) {
-      max_n_has_max_q_plus_m = (max_n == n);
-      max_q_plus_m = q_plus_m;
+    if (!max_n_has_max_q_plus_m) {
+      stats->time_usage_hint_ = IterationStats::TimeUsageHint::kNeedMoreTime;
     }
-  }
-  if (!max_n_has_max_q_plus_m) {
-    stats->time_usage_hint_ = IterationStats::TimeUsageHint::kNeedMoreTime;
   }
 }
 
@@ -986,7 +1003,11 @@ void SearchWorker::ExecuteOneIteration() {
   // If required, waste time to limit nps.
   if (params_.GetNpsLimit() > 0) {
     while (search_->IsSearchActive()) {
-      auto time_since_first_batch_ms = search_->GetTimeSinceFirstBatch();
+      int64_t time_since_first_batch_ms = 0;
+      {
+        Mutex::Lock lock(search_->counters_mutex_);
+        time_since_first_batch_ms = search_->GetTimeSinceFirstBatch();
+      }
       if (time_since_first_batch_ms <= 0) {
         time_since_first_batch_ms = search_->GetTimeSinceStart();
       }
@@ -1576,6 +1597,7 @@ void SearchWorker::FetchMinibatchResults() {
 
 void SearchWorker::FetchSingleNodeResult(NodeToProcess* node_to_process,
                                          int idx_in_computation) {
+  if (node_to_process->IsCollision()) return;
   Node* node = node_to_process->node;
   if (!node_to_process->nn_queried) {
     // Terminal nodes don't involve the neural NetworkComputation, nor do

--- a/src/mcts/search.h
+++ b/src/mcts/search.h
@@ -185,7 +185,9 @@ class Search {
   uint16_t max_depth_ GUARDED_BY(nodes_mutex_) = 0;
   // Cumulative depth of all paths taken in PickNodetoExtend.
   uint64_t cum_depth_ GUARDED_BY(nodes_mutex_) = 0;
-  std::optional<std::chrono::steady_clock::time_point> nps_start_time_;
+
+  std::optional<std::chrono::steady_clock::time_point> nps_start_time_
+      GUARDED_BY(counters_mutex_);
 
   std::atomic<int> pending_searchers_{0};
 

--- a/src/selfplay/game.cc
+++ b/src/selfplay/game.cc
@@ -277,6 +277,8 @@ void SelfPlayGame::Play(int white_threads, int black_threads, bool training,
           search_->GetParams().GetHistoryFill(), input_format, best_eval,
           played_eval, orig_eval, best_is_proof, best_move, move));
     }
+    // Must reset the search before mutating the tree.
+    search_.reset();
 
     // Add best move to the tree.
     tree_[0]->MakeMove(move);


### PR DESCRIPTION
* Fix multiple tsan reported issues.

1) GetBestChildrenNoTemperature was not respecting the GetN test before accessing a node's details.
2) PopulateCommonIterationStats had similar issues.
3) GetTwoFoldDraws property was used by SearchWorkers without being cached.
4) Wrap std::localtime usage in a mutex.
5) Fix a pointless access of node WL/D/M for collisions.
6) Put nps_start_time_ behind counters mutex to avoid races.
7) Ensure search is disposed before performing the move during selfplay.

* Formatting.

* Remove redundant HasNode check.